### PR TITLE
chore: update rust sdk to fix tweets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ chrono     = {version = "0.4", features = ["serde"]}
 rand       = "0.8.5"
 http       = "0.2"
 serde      = { version = "1.0", features = ["derive"] }
-spin-sdk   = { git = "https://github.com/fermyon/spin", rev = "232567f2b6c6b6d8145b5a7fdd42452ed69639e6" }
+spin-sdk   = { git = "https://github.com/fermyon/spin", rev = "139c40967a75dbdd5d4da2e626d24e68f54c0a5a" }


### PR DESCRIPTION
This version of spin SDK handles the URL query parameters properly which resolves the issue with tweets as in https://github.com/fermyon/bartholomew/issues/113.

Signed-off-by: karthik Ganeshram <karthik.ganeshram@fermyon.com>